### PR TITLE
Remove cache updating params

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -57,10 +57,10 @@ If a library is built for and/or only works within a specific application and/or
 
 Many people use VBA in business environments because they don't have better tools available. Dependency download may be blocked, or installation may be something that can only be done by IT staff.
 
-[o_32]: ./resources/32-Bit.svg?v=2 "32-bit only"
-[o_pass]: ./resources/Padlock.svg?v=2 "VBA is password protected"
+[o_32]: ./resources/32-Bit.svg "32-bit only"
+[o_pass]: ./resources/Padlock.svg "VBA is password protected"
 [o_dll]: ./resources/Dependencies.svg
-[o_inst]: ./resources/Installation.svg?v=3 "Requires installation"
+[o_inst]: ./resources/Installation.svg "Requires installation"
 [o_paid]: ./resources/Money.svg
 
 * [![o_dll]](#- "Requires external dependencies") - Requires external dependencies e.g. DLLs

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Because of the nature of VBA, many libraries do not work on all Operating System
 
 #### Other important information
 
-[o_32]: ./resources/32-Bit.svg?v=2 "32-bit only"
-[o_pass]: ./resources/Padlock.svg?v=2 "VBA is password protected"
+[o_32]: ./resources/32-Bit.svg "32-bit only"
+[o_pass]: ./resources/Padlock.svg "VBA is password protected"
 [o_dll]: ./resources/Dependencies.svg
-[o_inst]: ./resources/Installation.svg?v=3 "Requires installation"
+[o_inst]: ./resources/Installation.svg "Requires installation"
 [o_paid]: ./resources/Money.svg
 
 * [![o_32]](#-) - 32-bit only 


### PR DESCRIPTION
Looks like having a query param in the URL for the SVGs causes issue with the Andoid mobile app. Those were useful to use to force the cache update of those images while making changes, but we can safely remove those now.

I've reported the bug the GitHub, but to fix it quickly for now, I've just removed them.

How it looked on the mobile app before the change:
![image](https://user-images.githubusercontent.com/31558169/229365475-b0bc5714-d09d-4fa1-90fd-063d46fceb36.png)