### PR TITLE
Add linter on demand

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,11 @@
+on: workflow_dispatch
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: awesome-lint
+        run: npx awesome-lint


### PR DESCRIPTION
At least during the process of being added to the official Awesome List, it would be useful to have a quick access to run the linter from the Actions tab.