### PR TITLE
Added ASF

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Because of the nature of VBA, many libraries do not work on all Operating System
 
 ### Parsers / Interpreters
 
+- [![p_win]](#-) [![p_mac]](#-) [![a_all]](#-) ![GHStars](https://img.shields.io/github/stars/ECP-Solutions/ASF?style&logo=github&label) [Advanced Scripting Framework (ASF)](https://github.com/ECP-Solutions/ASF) - Full featured scripting language and runtime with C-like syntax, closures, FFI for VBA calls and native regex support.
 - [![p_win]](#-) [![p_nom]](#-) [![a_all]](#-) ![GHStars](https://img.shields.io/github/stars/sihlfall/vba-regex?style&logo=github&label) [vba-regex](https://github.com/sihlfall/vba-regex) - A native regex expression parser and runtime engine.
 - [![p_win]](#-) [![p_nom]](#-) [![a_all]](#-) ![GHStars](https://img.shields.io/github/stars/wqweto/VbPeg?style&logo=github&label) [VbPeg](https://github.com/wqweto/VbPeg) - A parser generator for VBA. Converts PEG grammar like [this](https://github.com/wqweto/VbPeg/blob/master/test/Runner/peg/Kscope/grammar.peg) into [VBA code like this](https://github.com/wqweto/VbPeg/blob/master/test/Runner/peg/Kscope/cKscope.cls). Very useful if your implementing a new programming language in VBA. Wqweto has also included some math expression parsers as tests.
 - [![p_win]](#-) [![p_mac]](#-) [![a_all]](#-) [Volpi's Math Expression Parser](https://web.archive.org/web/20100703220609/http://digilander.libero.it/foxes/mathparser/MathExpressionsParser.htm) - A fast math expression parser. Doesn't allow calls to objects, no callstack.


### PR DESCRIPTION
## Summary

ASF v1.0.6 now features a powerful native regular expression engine and a large set of JavaScript-style string methods — bringing JavaScript-like text processing and template literals natively to ASF scripts.

---

## Highlights

-  **Added** 
    - Native regex engine with support for:
		- Anchors, character classes and ranges, escapes (`\d`, `\D`, `\w`, `\s`, etc.).
		- Greedy / lazy / **possessive** quantifiers and **atomic groups**.
		- Lookaheads (`(?=...)`, `(?!...)`) and **fixed-width lookbehinds** (`(?<=...)`, `(?<!...)`) with compile-time rejection of variable-width lookbehind expressions.
		- Nested groups, captures and safe pretty-printing of capture results.
		- `RegExp.escape()` functionality (escape an arbitrary string to be used as a literal pattern).
    - **JS-like String API** methods implemented as ASF builtins:  
		- `replace`/`replaceAll` support both string and function replacement, and accept `/pattern/flags` slash-regex strings (flags: `g`, `i`, `m`, `s`). Function replacements receive `(match, p1...pn, offset, originalString)` — offset is zero-based. ```js fun replacer(match, p1, p2, p3, offset, string){return [p1,p2,p3].join(' - ');}  newString = 'abc12345#$*%'.replace('/(\\D*)(\\d*)(\\W*)/g', replacer); ```
- **Internal core change**:
	- Parser & compiler:
		- String templates (backtick syntax) with `${...}` placeholders:
			- Full expression support inside `${...}`; nested `${...}` supported.
			- Literal parts preserve escaped characters (outside placeholders): `\` escapes "\`", "/", "\".
			- Literal parts preserve escaped characters (inside placeholders): `\` **also** escapes `$`, `{`, `}`.
			- Examples: ```js a='Happy! '; return(`I feel ${a.repeat(3)}`); // -> Outputs 'I feel Happy! Happy! Happy! ' ```
		- Template tokenizer replaced with a robust `ParseTemplatePartsFromString` that emits a `Collection` of `Array("LITERAL", text)` and `Array("EXPR", text)` parts — each `${...}` is captured as an `EXPR` exactly as typed respecting escaping rules inside.
		- Recursive-descent expression parser improved so parenthesized expressions consume and allow postfix chaining (member calls, indexing, function calls) after the closing `)`.
- **Fixed**: 
	- Template tokenizer: fixed duplicated literal pieces, correct handling of nested ${...} and escaped characters inside literal parts.